### PR TITLE
Add simple test to demonstrate Core SDK warning

### DIFF
--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -8,7 +8,8 @@
     "lint": "eslint .",
     "start": "ts-node src/worker.ts",
     "start.watch": "nodemon src/worker.ts",
-    "workflow": "ts-node src/client.ts"
+    "workflow": "ts-node src/client.ts",
+    "test": "ts-node src/test.ts"
   },
   "nodemonConfig": {
     "execMap": {
@@ -27,6 +28,7 @@
     "nanoid": "3.x"
   },
   "devDependencies": {
+    "@temporalio/testing": "1.0.0",
     "@tsconfig/node16": "^1.0.0",
     "@types/node": "^16.11.43",
     "@typescript-eslint/eslint-plugin": "^5.0.0",

--- a/hello-world/src/test.ts
+++ b/hello-world/src/test.ts
@@ -1,0 +1,38 @@
+import { TestWorkflowEnvironment } from '@temporalio/testing'
+import { Worker, DefaultLogger, Runtime } from '@temporalio/worker'
+import { WorkflowClient } from '@temporalio/client'
+
+import * as activities from './activities';
+import { example } from './workflows';
+
+const logger = new DefaultLogger('ERROR')
+Runtime.install({ logger })
+
+async function test () {
+  const env = await TestWorkflowEnvironment.create({
+    testServer: {
+      stdio: 'ignore',
+    },
+    logger
+  })
+  const worker = await Worker.create({
+    connection: env.nativeConnection,
+    workflowsPath: require.resolve('./workflows'),
+    activities,
+    taskQueue: 'hello-world'
+  })
+  const client = new WorkflowClient({
+    connection: env.connection,
+  })
+
+  await worker.runUntil(async () => {
+    await client.start(example, {
+      args: ['Temporal'],
+      taskQueue: 'hello-world',
+      workflowId: 'test-workflow'
+    })
+  })
+  await env.teardown()
+}
+
+test().catch(console.error)

--- a/hello-world/src/test.ts
+++ b/hello-world/src/test.ts
@@ -1,3 +1,5 @@
+import assert from 'assert'
+
 import { TestWorkflowEnvironment } from '@temporalio/testing'
 import { Worker, DefaultLogger, Runtime } from '@temporalio/worker'
 import { WorkflowClient } from '@temporalio/client'
@@ -25,13 +27,16 @@ async function test () {
     connection: env.connection,
   })
 
-  await worker.runUntil(async () => {
-    await client.start(example, {
+  const result = await worker.runUntil(async () => {
+    return client.execute(example, {
       args: ['Temporal'],
       taskQueue: 'hello-world',
       workflowId: 'test-workflow'
     })
   })
+
+  assert.equal(result, 'Hello, Temporal!')
+  
   await env.teardown()
 }
 


### PR DESCRIPTION
Adds a simple test to demonstrate the warning message generated by the Core SDK when running workflow tests. Use `yarn test` to run the test:

```
> yarn test
yarn run v1.22.18
$ ts-node src/test.ts
  2022-07-27T08:44:04.290368Z  WARN temporal_sdk_core::worker::workflow::workflow_stream: WFT poller died, shutting down

✨  Done in 2.67s.
```